### PR TITLE
Refine LSP setup for vim.lsp.config

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -1,19 +1,8 @@
 {
   "cmp-nvim-lsp": { "branch": "main", "commit": "a8912b88ce488f411177fc8aed358b04dc246d7b" },
-<<<<<<< HEAD
-  "cmp-path": { "branch": "main", "commit": "e52e640b7befd8113b3350f46e8cfcfe98fcf730" },
-  "lazy.nvim": { "branch": "main", "commit": "6c3bda4aca61a13a9c63f1c1d1b16b9d3be90d7a" },
-  "nightfox.nvim": { "branch": "main", "commit": "ba47d4b4c5ec308718641ba7402c143836f35aa9" },
-  "nvim-cmp": { "branch": "main", "commit": "b5311ab3ed9c846b585c0c15b7559be131ec4be9" },
-  "nvim-lspconfig": { "branch": "master", "commit": "169745f176f58becad80363c3f8f2315ed6bb365" },
-  "nvim-treesitter": { "branch": "master", "commit": "42fc28ba918343ebfd5565147a42a26580579482" },
-  "plenary.nvim": { "branch": "master", "commit": "857c5ac632080dba10aae49dba902ce3abf91b35" },
-  "telescope.nvim": { "branch": "master", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" },
-  "ultisnips": { "branch": "master", "commit": "b22a86f9dcc5257624bff3c72d8b902eac468aad" },
-  "vimtex": { "branch": "master", "commit": "7f2633027c8f496a85284de0c11aa32f1e07e049" }
-=======
   "cmp-path": { "branch": "main", "commit": "c6635aae33a50d6010bf1aa756ac2398a2d54c32" },
   "lazy.nvim": { "branch": "main", "commit": "6c3bda4aca61a13a9c63f1c1d1b16b9d3be90d7a" },
+  "mason.nvim": { "branch": "main", "commit": "a83eabdc8c49c0c93bf5bb162fa3b57404a9d095" },
   "nightfox.nvim": { "branch": "main", "commit": "ba47d4b4c5ec308718641ba7402c143836f35aa9" },
   "nvim-cmp": { "branch": "main", "commit": "059e89495b3ec09395262f16b1ad441a38081d04" },
   "nvim-lspconfig": { "branch": "master", "commit": "4ea9083b6d3dff4ddc6da17c51334c3255b7eba5" },
@@ -22,5 +11,4 @@
   "telescope.nvim": { "branch": "master", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" },
   "ultisnips": { "branch": "master", "commit": "dbc458e110bb49299da76ec53f8b09b4f6dce28a" },
   "vimtex": { "branch": "master", "commit": "a531f6bf9ce61172e4ea8eea2ecbf59fd08c232a" }
->>>>>>> ac65b5c1d5b1ea32fc1716703c74dbe5c7949ae5
 }

--- a/lua/jupiter/lazy/lsp.lua
+++ b/lua/jupiter/lazy/lsp.lua
@@ -1,98 +1,112 @@
+local mason_packages = {
+  "lua-language-server",
+  "pyright",
+  "rust-analyzer",
+  "html-lsp",
+  "css-lsp",
+  "typescript-language-server",
+  "svelte-language-server",
+}
+
 return {
- "neovim/nvim-lspconfig",
- dependencies = {
-     "hrsh7th/nvim-cmp",
-     "hrsh7th/cmp-nvim-lsp",
-     'hrsh7th/cmp-path',
- },
- config = function ()
-     local lspconfig_defaults = require('lspconfig').util.default_config
-     lspconfig_defaults.capabilities = vim.tbl_deep_extend(
-     'force',
-     lspconfig_defaults.capabilities,
-     require('cmp_nvim_lsp').default_capabilities()
-     )
+  {
+    "williamboman/mason.nvim",
+    build = ":MasonUpdate",
+    opts = {
+      ensure_installed = mason_packages,
+    },
+    config = function(_, opts)
+      local mason = require("mason")
+      mason.setup(opts)
 
-     -- This is where you enable features that only work
-     -- if there is a language server active in the file
-     vim.api.nvim_create_autocmd('LspAttach', {
-         desc = 'LSP actions',
-         callback = function(event)
-             local opts = {buffer = event.buf}
-             vim.keymap.set('n', 'K', '<cmd>lua vim.lsp.buf.hover()<cr>', opts)
-             vim.keymap.set('n', 'gd', '<cmd>lua vim.lsp.buf.definition()<cr>', opts)
-             vim.keymap.set('n', 'gD', '<cmd>lua vim.lsp.buf.declaration()<cr>', opts)
-             vim.keymap.set('n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<cr>', opts)
-             vim.keymap.set('n', 'go', '<cmd>lua vim.lsp.buf.type_definition()<cr>', opts)
-             vim.keymap.set('n', 'gr', '<cmd>lua vim.lsp.buf.references()<cr>', opts)
-             vim.keymap.set('n', 'gs', '<cmd>lua vim.lsp.buf.signature_help()<cr>', opts)
-             vim.keymap.set('n', '<F2>', '<cmd>lua vim.lsp.buf.rename()<cr>', opts)
-             vim.keymap.set({'n', 'x'}, '<F3>', '<cmd>lua vim.lsp.buf.format({async = true})<cr>', opts)
-             vim.keymap.set('n', '<F4>', '<cmd>lua vim.lsp.buf.code_action()<cr>', opts)
-         end,
-     })
+      local registry = require("mason-registry")
+      for _, tool in ipairs(opts.ensure_installed or {}) do
+        local ok, pkg = pcall(registry.get_package, tool)
+        if ok and not pkg:is_installed() then
+          pkg:install()
+        end
+      end
+    end,
+  },
+  {
+    "neovim/nvim-lspconfig",
+    dependencies = {
+      "hrsh7th/nvim-cmp",
+      "hrsh7th/cmp-nvim-lsp",
+      "hrsh7th/cmp-path",
+      "williamboman/mason.nvim",
+    },
+    config = function()
+      local cmp = require("cmp")
+      local cmp_capabilities = require("cmp_nvim_lsp").default_capabilities()
 
-     -- You'll find a list of language servers here:
-     -- https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md
-     -- These are example language servers. 
-     -- require('lspconfig').gleam.setup({})
-     -- require('lspconfig').ocamllsp.setup({})
-     require('lspconfig').pyright.setup{}
-     require('lspconfig').rust_analyzer.setup{}
-     require'lspconfig'.html.setup{}
-     require'lspconfig'.cssls.setup{}
-     require'lspconfig'.ts_ls.setup{}
-     require'lspconfig'.svelte.setup{}
-     require'lspconfig'.lua_ls.setup {
-         on_init = function(client)
-             if client.workspace_folders then
-                 local path = client.workspace_folders[1].name
-                 if vim.uv.fs_stat(path..'/.luarc.json') or vim.uv.fs_stat(path..'/.luarc.jsonc') then
-                     return
-                 end
-             end
+      local defaults = rawget(vim.lsp.config, "*") or {}
+      vim.lsp.config("*", vim.tbl_deep_extend("force", {}, defaults, {
+        capabilities = vim.tbl_deep_extend("force", {}, defaults.capabilities or {}, cmp_capabilities),
+      }))
 
-             client.config.settings.Lua = vim.tbl_deep_extend('force', client.config.settings.Lua, {
-                 runtime = {
-                     -- Tell the language server which version of Lua you're using
-                     -- (most likely LuaJIT in the case of Neovim)
-                     version = 'LuaJIT'
-                 },
-                 -- Make the server aware of Neovim runtime files
-                 workspace = {
-                     checkThirdParty = false,
-                     library = {
-                         vim.env.VIMRUNTIME
-                         -- Depending on the usage, you might want to add additional paths here.
-                         -- "${3rd}/luv/library"
-                         -- "${3rd}/busted/library",
-                     }
-                     -- or pull in all of 'runtimepath'. NOTE: this is a lot slower and will cause issues when working on your own configuration (see https://github.com/neovim/nvim-lspconfig/issues/3189)
-                     -- library = vim.api.nvim_get_runtime_file("", true)
-                 }
-             })
-         end,
-         settings = {
-             Lua = {}
-         }
-     }
+      vim.api.nvim_create_autocmd("LspAttach", {
+        desc = "LSP keymaps",
+        callback = function(event)
+          local lsp_buf = vim.lsp.buf
+          local opts = { buffer = event.buf }
 
-     local cmp = require('cmp')
+          vim.keymap.set("n", "K", lsp_buf.hover, opts)
+          vim.keymap.set("n", "gd", lsp_buf.definition, opts)
+          vim.keymap.set("n", "gD", lsp_buf.declaration, opts)
+          vim.keymap.set("n", "gi", lsp_buf.implementation, opts)
+          vim.keymap.set("n", "go", lsp_buf.type_definition, opts)
+          vim.keymap.set("n", "gr", lsp_buf.references, opts)
+          vim.keymap.set("n", "gs", lsp_buf.signature_help, opts)
+          vim.keymap.set("n", "<F2>", lsp_buf.rename, opts)
+          vim.keymap.set({ "n", "x" }, "<F3>", function()
+            lsp_buf.format({ async = true })
+          end, opts)
+          vim.keymap.set("n", "<F4>", lsp_buf.code_action, opts)
+        end,
+      })
 
-     cmp.setup({
-         sources = {
-             {name = 'nvim_lsp'},
-             {name = 'path'},
-         },
-         snippet = {
-             expand = function(args)
-                 -- You need Neovim v0.10 to use vim.snippet
-                 vim.snippet.expand(args.body)
-             end,
-         },
-         mapping = cmp.mapping.preset.insert({
-             ['<C-CR>'] = cmp.mapping.confirm({ select = true }),
-         }),
-     })
-end
+      local server_settings = {
+        lua_ls = {
+          settings = {
+            Lua = {
+              workspace = { checkThirdParty = false },
+              telemetry = { enable = false },
+              hint = { enable = true },
+            },
+          },
+        },
+        pyright = {},
+        rust_analyzer = {},
+        html = {},
+        cssls = {},
+        ts_ls = {},
+        svelte = {},
+      }
+
+      for server, cfg in pairs(server_settings) do
+        if cfg and next(cfg) ~= nil then
+          local existing = rawget(vim.lsp.config, server) or {}
+          vim.lsp.config(server, vim.tbl_deep_extend("force", {}, existing, cfg))
+        end
+      end
+
+      vim.lsp.enable(vim.tbl_keys(server_settings))
+
+      cmp.setup({
+        sources = {
+          { name = "nvim_lsp" },
+          { name = "path" },
+        },
+        snippet = {
+          expand = function(args)
+            vim.snippet.expand(args.body)
+          end,
+        },
+        mapping = cmp.mapping.preset.insert({
+          ["<C-CR>"] = cmp.mapping.confirm({ select = true }),
+        }),
+      })
+    end,
+  },
 }


### PR DESCRIPTION
## Summary
- resolve the lazy-lock merge conflict and pin mason.nvim alongside the existing plugins
- migrate the LSP bootstrap to pure `vim.lsp.config`, ensuring Mason installs the requested servers and keeping the cmp keymaps and sources intact

## Testing
- /tmp/nvim-linux-x86_64/bin/nvim --headless +qall

------
https://chatgpt.com/codex/tasks/task_e_68dd0d71ff348326896e64d7dbaa9dff