### PR TITLE
Switch to Ruff language server

### DIFF
--- a/lua/jupiter/lazy/lsp.lua
+++ b/lua/jupiter/lazy/lsp.lua
@@ -1,7 +1,7 @@
 local mason_packages = {
   "lua-language-server",
   "basedpyright",
-  "ruff-lsp",
+  "ruff",
   "rust-analyzer",
   "clangd",
   "dockerfile-language-server",
@@ -94,7 +94,7 @@ return {
             },
           },
         },
-        ruff_lsp = {},
+        ruff = {},
         rust_analyzer = {},
         clangd = {},
         dockerls = {},


### PR DESCRIPTION
## Summary
- replace the deprecated `ruff-lsp` adapter with the native `ruff` language server in the Mason and LSP configurations

## Testing
- `nvim --headless -u init.lua +qa` *(fails: command not found in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68dd80aeaaa08326b00a48328216a414