### PR TITLE
Add Java and Android development tooling

### DIFF
--- a/lua/jupiter/lazy/treesitter.lua
+++ b/lua/jupiter/lazy/treesitter.lua
@@ -6,7 +6,7 @@ return {
 
         configs.setup({
   -- A list of parser names, or "all" (the listed parsers MUST always be installed)
-    ensure_installed = {"lua", "vim", "vimdoc", "query", "markdown", "markdown_inline", "latex", "rust", "html", "javascript", "python", "typescript", "svelte"},
+    ensure_installed = {"lua", "vim", "vimdoc", "query", "markdown", "markdown_inline", "latex", "rust", "html", "javascript", "python", "typescript", "svelte", "java", "kotlin", "xml"},
 
   -- Install parsers synchronously (only applied to `ensure_installed`)
   sync_install = false,


### PR DESCRIPTION
## Summary
- ensure Mason installs Java, Kotlin, and Android language tooling including formatters and debuggers
- configure the modern vim.lsp interface for jdtls, kotlin-language-server, and android-language-server with project-aware workspaces and formatting defaults
- install additional Tree-sitter parsers for Java, Kotlin, and XML syntax highlighting

## Testing
- Not run (Neovim binary unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e253eff98483268802d7fbafaf657a